### PR TITLE
Fixed incorrect use of Bootstrap's grid system

### DIFF
--- a/app/views/phase.erb
+++ b/app/views/phase.erb
@@ -1,8 +1,12 @@
 <h1 data-flippd-phase="<%= @phase["id"]%>"><%= @phase["title"] %></h1>
 <p class="lead"><%= @phase["summary"] %></p>
 
-<div id="topics" class="row">
+<div id="topics">
   <% @phase["topics"].each_with_index do |topic, index| %>
+  <% if index % 2 == 0 %>
+    <div class="row">
+    <% closed = false %>
+  <% end %>
   <div class="col-md-6" style="padding-top: 15px;">
     <h4><%=index+1%>. <%=topic["title"]%></h4>
 
@@ -18,5 +22,12 @@
     <% end %>
     </ul>
   </div>
+  <% if index % 2 == 1 %>
+    </div>
+    <% closed = true %>
+  <% end %>
+  <% end %>
+  <% if not closed %>
+    </div>
   <% end %>
 </div>


### PR DESCRIPTION
Currently, the phase page rather arranges awkwardly when unevenly tall objects are present:

![before](http://i.imgur.com/UrCKWlC.png)

This is because an unlimited amount of `.col-md-6`s are being stuffed into a single row, which was only meant to take up to 12 width items (2 items).

This fix just wraps a `.row` div every 2 items.
